### PR TITLE
fix: change links to staging

### DIFF
--- a/cranecloud/docs/authentication/forgotPassword.md
+++ b/cranecloud/docs/authentication/forgotPassword.md
@@ -1,12 +1,12 @@
 ## Forgot Password
 **User Actions:**
 
-Once you click the forgot password link on the login page, it will lead you to this route http://cranecloud.io/forgot-password that displays a page for you to enter your email address.
+Once you click the forgot password link on the login page, it will lead you to this route <http://cranecloud.io/forgot-password> that displays a page for you to enter your email address.
 Enter your email address corresponding to the one used at the time of account registration.
 
 **Expected Behaviour:**
 
-*IF* the email provided does not match any user account, the following error shall display, “Invalid user, please create an account “. You are required to navigate to http://staging.cranecloud.io/forgot-password and create an account with Crane Cloud in such a scenario.
+*IF* the email provided does not match any user account, the following error shall display, “Invalid user, please create an account “. You are required to navigate to <http://staging.cranecloud.io/forgot-password> and create an account with Crane Cloud in such a scenario.
 
 *IF* the email provided is right and matches a registered account, a password update link shall be sent to your email. Note that the link will expire after 24 hours. Follow the link sent and it should land you to the page with provision to enter your new password.
 ![](../img/new_password.png)

--- a/cranecloud/docs/authentication/login.md
+++ b/cranecloud/docs/authentication/login.md
@@ -1,5 +1,5 @@
 ## Login
-1\. Browse this URL http://staging.cranecloud.io/login to access the Crane Cloud login portal, similar to the one below
+1\. Browse this URL <http://staging.cranecloud.io/login> to access the Crane Cloud login portal, similar to the one below
 ![](../img/login_page.png)
 
 Enter your email address and password, then  click LOGIN 

--- a/cranecloud/docs/authentication/registration.md
+++ b/cranecloud/docs/authentication/registration.md
@@ -1,5 +1,5 @@
 ## Registration
-1\. To register visit http://staging.cranecloud.io/ and click the `GET STARTED `Button
+1\. To register visit <http://staging.cranecloud.io/> and click the `GET STARTED `Button
 ![](../img/get_started.png)
 
 Alternatively you can click the `Create an account` link on the *Login page.*

--- a/cranecloud/docs/index.md
+++ b/cranecloud/docs/index.md
@@ -16,3 +16,5 @@ Crane Cloud is managed cloud service platform that supports:
 * Application Monitoring
 * Service scheduling
 * Auto scaling and replication
+
+Visit <http://staging.cranecloud.io/> today to get started.

--- a/cranecloud/docs/quickstart/quickstart.md
+++ b/cranecloud/docs/quickstart/quickstart.md
@@ -1,5 +1,7 @@
+# QUICK START
+
 ## Registration
-1. Visit cranecloud.io and click the `GET STARTED Button`
+1. Visit <http://staging.cranecloud.io/> and click the `GET STARTED Button`
 ![](../img/get_started.png)
 
 2. Fill in all the required information, agree to terms and conditions and click `Register`

--- a/cranecloud/mkdocs.yml
+++ b/cranecloud/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Crane Cloud
 nav:
-  - quickstart:
+  - Quickstart:
       - quickstart: quickstart/quickstart.md
   - Authentication:
       - Registration: authentication/registration.md


### PR DESCRIPTION
### What does this PR do?
It simply: 

- changes links to staging.cranecloud.io 

- Makes links clickable

- Adds a call back url for main site to docs landing page 

- Capitalize first letter quick start side tab name 

Screenshots 
![Screenshot from 2020-06-19 12-12-27](https://user-images.githubusercontent.com/36065782/85116683-5bfc8a80-b226-11ea-851c-a19269149264.png)

call back link 
![Screenshot from 2020-06-19 12-14-12](https://user-images.githubusercontent.com/36065782/85116732-720a4b00-b226-11ea-98d3-fcfa3299acc2.png)

