### PR TITLE
fix: update url and make it clickable

### DIFF
--- a/cranecloud/docs/applications/appContainerization.md
+++ b/cranecloud/docs/applications/appContainerization.md
@@ -3,4 +3,4 @@ A container is a standard unit of software that packages up code and all it's de
 
 **Container images become containers at runtime.**
 
-If you have your application already containerized jump to the next section. If you have no need help containerizing you could use ![this resource](https://docs.docker.com/develop).
+If you have your application already containerized jump to the next section. If you have no need help containerizing you could use this resource <https://docs.docker.com/develop>.

--- a/cranecloud/docs/authentication/forgotPassword.md
+++ b/cranecloud/docs/authentication/forgotPassword.md
@@ -6,7 +6,7 @@ Enter your email address corresponding to the one used at the time of account re
 
 **Expected Behaviour:**
 
-*IF* the email provided does not match any user account, the following error shall display, “Invalid user, please create an account “. You are required to navigate to <http://staging.cranecloud.io/forgot-password> and create an account with Crane Cloud in such a scenario.
+*IF* the email provided does not match any user account, the following error shall display, “Invalid user, please create an account “. You are required to navigate to <http://staging.cranecloud.io> and create an account with Crane Cloud in such a scenario.
 
 *IF* the email provided is right and matches a registered account, a password update link shall be sent to your email. Note that the link will expire after 24 hours. Follow the link sent and it should land you to the page with provision to enter your new password.
 ![](../img/new_password.png)


### PR DESCRIPTION
### What does this PR do?
It changes the URL in the reset password page that leads to the landing page .
It was previously this:
![Screenshot from 2020-06-19 12-51-19](https://user-images.githubusercontent.com/36065782/85120214-9caad280-b22b-11ea-87f5-4638bbb563ff.png)

It makes the resource link for image containerization visible and clickable.
It was previously this:
![Screenshot from 2020-06-19 12-52-52](https://user-images.githubusercontent.com/36065782/85120362-d24fbb80-b22b-11ea-96ed-ccd2185bfe4f.png)
