### PR TITLE
Add PR template to repo

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+# Description
+
+Please include a summary of what the PR does adding Please relevant motivation and context.
+
+## Type of change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+## Trello Ticket ID
+
+Please add a link to the Trello ticket for the task.
+
+## How Can This Been Tested?
+
+Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test scenario/configuration
+
+## Checklist:
+
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] My changes generate no new warnings
+- [ ] Any dependent changes have been merged and published in downstream modules
+
+# Screenshots
+
+Add relevant screenshots incase they are relevant


### PR DESCRIPTION
#### What does this PR do?
It creates a PR template for the Documentation repo

#### Ticket
https://trello.com/c/gRUtvWUe

#### Screenshots
![Screenshot from 2021-06-21 10-59-35](https://user-images.githubusercontent.com/32802973/122728297-a91f9c00-d280-11eb-877d-96edf49978a3.png)
![Screenshot from 2021-06-21 10-59-45](https://user-images.githubusercontent.com/32802973/122728311-ac1a8c80-d280-11eb-827e-3a274eae0e55.png)
