### PR TITLE
Update clusters for production deployments.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ deploy_to_kubernetes: &deploy_to_kubernetes
     name: update deployment image
     command: |
       export IMG_TAG=$(echo $CIRCLE_SHA1 | cut -c -7)
-      ./kubectl set image deployment/cranecloud-docs cranecloud-docs=gcr.io/$GCP_PROJECT_ID/cranecloud-docs:$IMG_TAG --record -n cranecloud
+      ./kubectl set image deployment/cranecloud-docs cranecloud-docs=gcr.io/$GCP_PROJECT_ID/cranecloud-docs:$IMG_TAG --record -n $namespace
 
 
 jobs:
@@ -40,6 +40,7 @@ jobs:
         environment:
           GOOGLE_APPLICATION_CREDENTIALS: /root/crane-cloud
           cluster: staging-cluster
+          namespace: cranecloud
     working_directory: ~/crane-cloud
     steps:
       - checkout
@@ -58,7 +59,8 @@ jobs:
       - image: google/cloud-sdk
         environment:
           GOOGLE_APPLICATION_CREDENTIALS: /root/crane-cloud
-          cluster: production-cluster
+          cluster: staging-cluster
+          namespace: cranecloud-prod
     working_directory: ~/crane-cloud
     steps:
       - checkout


### PR DESCRIPTION

## Problem
Deployments to production were failing due to a missing cluster.  At one point in time we had separate clusters for staging and production on GCP but that has since changed.

## Solution
Update the circleci configs to deployment to the same cluster.